### PR TITLE
Updating the SHA3 example for recent chisel/rocket changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You can then test it using the emulator
     cd ../emulator && make CONFIG=Sha3CPPConfig run-asm-tests
 
 You can emulate the software implementation of sha3 by running
+
     ./emulator-Top-Sha3CPPConfig pk ../sha3/tests/sha3-sw.rv +dramsim
 
 or

--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ If cloned into rocket-chip directory use
 You can then test it using the emulator
 
     cd ../emulator && make CONFIG=Sha3CPPConfig run-asm-tests
+
+You can emulate the software implementation of sha3 by running
+    ./emulator-Top-Sha3CPPConfig pk ../sha3/tests/sha3-sw.rv +dramsim
+
+or
+
+    ./emulator-Top-Sha3CPPConfig pk ../sha3/tests/sha3-sw-bm.rv +dramsim
+
+You can emulate the accelerated sha3 by running
+    ./emulator-Top-Sha3CPPConfig pk ../sha3/tests/sha3-rocc-bm.rv +dramsim
+
+or 
+
+    ./emulator-Top-Sha3CPPConfig pk ../sha3/tests/sha3-rocc.rv +dramsim
+
+The -bm versions of the code omit the print statements and will complete faster.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ or
     ./emulator-Top-Sha3CPPConfig pk ../sha3/tests/sha3-sw-bm.rv +dramsim
 
 You can emulate the accelerated sha3 by running
+
     ./emulator-Top-Sha3CPPConfig pk ../sha3/tests/sha3-rocc-bm.rv +dramsim
 
 or 

--- a/config/Makefrag
+++ b/config/Makefrag
@@ -1,0 +1,72 @@
+# check RISCV environment variable
+ifndef RISCV
+$(error Please set environment variable RISCV. Please take a look at README)
+endif
+
+MODEL ?= Top
+PROJECT := rocketchip
+
+#this defines a list of addons to build and is set as an env var
+export ROCKETCHIP_ADDONS ?= sha3
+
+CXX ?= g++
+CXXFLAGS := -O1
+
+SBT := java -Xmx2048M -Xss8M -XX:MaxPermSize=128M -jar sbt-launch.jar
+SHELL := /bin/bash
+
+CHISEL_ARGS := $(PROJECT) $(MODEL) $(CONFIG) --W0W --minimumCompatibility 3.0.0 --backend $(BACKEND) --configName $(CONFIG) --compileInitializationUnoptimized --targetDir $(generated_dir)
+
+src_path = src/main/scala
+default_submodules = . junctions uncore hardfloat rocket zscale groundtest
+chisel_srcs = $(addprefix $(base_dir)/,$(addsuffix /$(src_path)/*.scala,$(default_submodules) $(ROCKETCHIP_ADDONS)))
+
+disasm := 2>
+which_disasm := $(shell which spike-dasm 2> /dev/null)
+ifneq ($(which_disasm),)
+	disasm := 3>&1 1>&2 2>&3 | $(which_disasm) $(DISASM_EXTENSION) >
+endif
+
+timeout_cycles = 100000000
+
+#--------------------------------------------------------------------
+# DRAMSim2
+#--------------------------------------------------------------------
+
+DRAMSIM_OBJS := $(patsubst %.cpp,%.o,$(wildcard $(base_dir)/dramsim2/*.cpp))
+$(DRAMSIM_OBJS): %.o: %.cpp
+	$(CXX) $(CXXFLAGS) -DNO_STORAGE -DNO_OUTPUT -Dmain=nomain -c -o $@ $<
+$(sim_dir)/libdramsim.a: $(DRAMSIM_OBJS)
+	ar rcs $@ $^
+
+#--------------------------------------------------------------------
+# Build Tests
+#--------------------------------------------------------------------
+
+%.hex:
+	$(MAKE) -C $(dir $@) $(notdir $@)
+
+%.riscv.hex: %
+	$(MAKE) -C $(dir $@) $(notdir $@)
+
+#---------------------------------------------------------------------
+# Constants Header Files
+#---------------------------------------------------------------------
+
+params_file = $(generated_dir)/$(MODEL).$(CONFIG).prm
+consts_header = $(generated_dir)/consts.$(CONFIG).h
+$(consts_header): $(params_file)
+	echo "#ifndef __CONST_H__" > $@
+	echo "#define __CONST_H__" >> $@
+	sed -r 's/\(([A-Za-z0-9_]+),([A-Za-z0-9_]+)\)/#define \1 \2/' $< >> $@
+	echo "#define TBFRAG \"$(MODEL).$(CONFIG).tb.cpp\"" >> $@
+	echo "#endif // __CONST_H__" >> $@
+
+params_file_debug = $(generated_dir_debug)/$(MODEL).$(CONFIG).prm
+consts_header_debug = $(generated_dir_debug)/consts.$(CONFIG).h
+$(consts_header_debug): $(params_file_debug)
+	echo "#ifndef __CONST_H__" > $@
+	echo "#define __CONST_H__" >> $@
+	sed -r 's/\(([A-Za-z0-9_]+),([A-Za-z0-9_]+)\)/#define \1 \2/' $< >> $@
+	echo "#define TBFRAG \"$(MODEL).$(CONFIG).tb.cpp\"" >> $@
+	echo "#endif // __CONST_H__" >> $@

--- a/config/PrivateConfigs.scala
+++ b/config/PrivateConfigs.scala
@@ -4,27 +4,33 @@ package rocketchip
 import Chisel._
 import uncore._
 import rocket._
+//import cde._
+import cde.{Parameters, Field, Config, Knob, Dump, World, Ex, ViewSym}
+import cde.Implicits._
 import sha3._
 
-import Implicits._
+//case object Width extends Field[Int]
+//case object Stages extends Field[Int]
+//case object FastMem extends Field[Boolean]
+//case object BufferSram extends Field[Boolean]
 
-class Sha3Config extends ChiselConfig {
+class Sha3Config extends Config {
   override val topDefinitions:World.TopDefs = {
     (pname,site,here) => pname match {
-      case "width" => 64
-      case "stages" => Knob("stages")
-      case "fast_mem" => Knob("fast_mem")
-      case "buffer_sram" => Dump(Knob("buffer_sram"))
-      case RoCCMaxTaggedMemXacts => 32
-      case BuildRoCC => Some(() => (Module(new Sha3Accel, { case CoreName => "Sha3" })))
+      case WidthP => 64
+      case Stages => Knob("stages")
+      case FastMem => Knob("fast_mem")
+      case BufferSram => Dump(Knob("buffer_sram"))
+      case RoccMaxTaggedMemXacts => 32
+      case BuildRoCC => Some((p: Parameters) => (Module(new Sha3Accel()(p), { case CoreName => "rocket" })))
     }
   }
  
   override val topConstraints:List[ViewSym=>Ex[Boolean]] = List(
-    ex => ex[Int]("width") === 64,
-    ex => ex[Int]("stages") >= 1 && ex[Int]("stages") <= 4 && (ex[Int]("stages")%2 === 0 || ex[Int]("stages") === 1),
-    ex => ex[Boolean]("fast_mem") === ex[Boolean]("fast_mem"),
-    ex => ex[Boolean]("buffer_sram") === ex[Boolean]("buffer_sram")
+    ex => ex(WidthP) === 64,
+    ex => ex(Stages) >= 1 && ex(Stages) <= 4 && (ex(Stages)%2 === 0 || ex(Stages) === 1),
+    ex => ex(FastMem) === ex(FastMem),
+    ex => ex(BufferSram) === ex(BufferSram)
     //ex => ex[Boolean]("multi_vt") === ex[Boolean]("multi_vt")
   )
   override val knobValues:Any=>Any = {
@@ -35,6 +41,6 @@ class Sha3Config extends ChiselConfig {
   }
 }
 
-class Sha3VLSIConfig extends ChiselConfig(new Sha3Config ++ new DefaultVLSIConfig)
-class Sha3FPGAConfig extends ChiselConfig(new Sha3Config ++ new DefaultFPGAConfig) 
-class Sha3CPPConfig extends ChiselConfig(new Sha3Config ++ new DefaultCPPConfig) 
+class Sha3VLSIConfig extends Config(new Sha3Config ++ new DefaultVLSIConfig)
+class Sha3FPGAConfig extends Config(new Sha3Config ++ new DefaultFPGAConfig) 
+class Sha3CPPConfig extends Config(new Sha3Config ++ new DefaultCPPConfig) 

--- a/install-symlinks
+++ b/install-symlinks
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #see LICENSE for license
 
-cd ../riscv-tools/riscv-isa-sim && ln -s ../../rocc-template/isa-sim/sha3 sha3
-rm configure.ac && ln -s ../../rocc-template/isa-sim/configure.ac
-cd ../../src/main/scala && ln -s ../../../rocc-template/config/PrivateConfigs.scala PrivateConfigs.scala
+cd ../ && ln -s rocc-template sha3
+mv Makefrag Makefrag.old && ln -s sha3/config/Makefrag Makefrag
+cd riscv-tools/riscv-isa-sim && ln -s ../../sha3/isa-sim/sha3 sha3
+mv configure.ac configure.ac.old && ln -s ../../sha3/isa-sim/configure.ac && ln -s ../../sha3/isa-sim/riscv-sha3.pc.in riscv-sha3.pc.in
+cd ../../src/main/scala && ln -s ../../../sha3/config/PrivateConfigs.scala PrivateConfigs.scala

--- a/isa-sim/configure.ac
+++ b/isa-sim/configure.ac
@@ -36,8 +36,8 @@ m4_define( proj_version, [?])
 # Setup
 #-------------------------------------------------------------------------
 
-AC_LANG_CPLUSPLUS
 AC_INIT(proj_name,proj_version,proj_maintainer,proj_abbreviation)
+AC_LANG_CPLUSPLUS
 AC_CONFIG_SRCDIR([riscv/common.h])
 AC_CONFIG_AUX_DIR([scripts])
 AC_CANONICAL_BUILD
@@ -81,7 +81,7 @@ AC_SUBST([CXXFLAGS],["-Wall -Wno-unused -O2 -std=c++11"])
 # The '*' suffix indicates an optional subproject. The '**' suffix
 # indicates an optional subproject which is also the name of a group.
 
-MCPPBS_SUBPROJECTS([ riscv, sha3, dummy_rocc, softfloat, spike_main ])
+MCPPBS_SUBPROJECTS([ riscv, sha3, hwacha, dummy_rocc, softfloat, spike_main ])
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject groups
@@ -100,4 +100,11 @@ MCPPBS_SUBPROJECTS([ riscv, sha3, dummy_rocc, softfloat, spike_main ])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([riscv-spike.pc])
+AC_CONFIG_FILES([riscv-riscv.pc])
+AC_CONFIG_FILES([riscv-hwacha.pc])
+AC_CONFIG_FILES([riscv-softfloat.pc])
+AC_CONFIG_FILES([riscv-dummy_rocc.pc])
+AC_CONFIG_FILES([riscv-sha3.pc])
+AC_CONFIG_FILES([riscv-spike_main.pc])
 AC_OUTPUT

--- a/isa-sim/riscv-sha3.pc.in
+++ b/isa-sim/riscv-sha3.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-sha3
+Description: Sha3
+Version: git
+Libs: -Wl,-rpath,${libdir} -L${libdir} -ldummy_rocc
+Cflags: -I${includedir}
+URL: http://riscv.org/download.html#tab_spike

--- a/src/main/scala/ctrl.scala
+++ b/src/main/scala/ctrl.scala
@@ -6,10 +6,12 @@ import Chisel._
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
+import cde.{Parameters, Config, Dump, Knob, Ex, ViewSym}
+import cde.Implicits._
 
 import uncore.constants.MemoryOpConstants._
 
-class CtrlModule(val W: Int, val S: Int) extends Module {//with MemoryOpConstants{
+class CtrlModule(val W: Int, val S: Int)(implicit p: Parameters) extends Module() {//with MemoryOpConstants{
   val r = 2*256
   val c = 25*W - r
   val round_size_words = c/W
@@ -71,11 +73,11 @@ class CtrlModule(val W: Int, val S: Int) extends Module {//with MemoryOpConstant
 
   val dmem_resp_tag_reg = Reg(next=io.dmem_resp_tag)
   //memory pipe state
-  val fast_mem = params[Boolean]("fast_mem")
+  val fast_mem = p(FastMem)
   val m_idle :: m_read :: m_wait :: m_pad :: m_absorb :: Nil = Enum(UInt(), 5)
   val mem_s = Reg(init=m_idle)
 
-  val buffer_sram = params[Boolean]("buffer_sram")
+  val buffer_sram = p(BufferSram)
   //SRAM Buffer
   val buffer_mem = Mem(UInt(width = W), round_size_words, seqRead = true)
   //Flip-Flop buffer


### PR DESCRIPTION
This is an update to SHA3 example to account for recent chisel/rocket changes.

This fix allows sha3-sw.rv, sha3-sw-bm.rv sha3-rocc.rv, sha3-rocc-bm.rv to be executed in both the emulator and vsim with the +dramsim flag.  The commands used are in the readme.

run-asm-tests currently does not work with the current repo due to a conflict with vector instructions.